### PR TITLE
Add DiscountEngine for risk-based discounting

### DIFF
--- a/src/main/java/com/smartexpiry/DiscountEngine.java
+++ b/src/main/java/com/smartexpiry/DiscountEngine.java
@@ -1,0 +1,19 @@
+package com.smartexpiry;
+
+public class DiscountEngine {
+    public static int getSuggestedDiscount(String riskLevel) {
+        if (riskLevel == null) {
+            throw new IllegalArgumentException("riskLevel cannot be null");
+        }
+        switch (riskLevel.toUpperCase()) {
+            case "HIGH":
+                return 30;
+            case "MEDIUM":
+                return 15;
+            case "LOW":
+                return 0;
+            default:
+                throw new IllegalArgumentException("Invalid risk level: " + riskLevel);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `DiscountEngine` class in `com.smartexpiry`
- implement static method `getSuggestedDiscount` to map risk level to discount percentage

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_684c2ea9a0b8832e9f82847a8654fae3