### PR TITLE
Add Main class to run SmartExpiry

### DIFF
--- a/src/main/java/com/smartexpiry/Main.java
+++ b/src/main/java/com/smartexpiry/Main.java
@@ -1,0 +1,24 @@
+package com.smartexpiry;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Entry point for the SmartExpiry application.
+ */
+public class Main {
+    /**
+     * Reads inventory items from a CSV file and displays them via the console UI.
+     *
+     * @param args command line arguments (unused)
+     */
+    public static void main(String[] args) {
+        DataReader reader = new DataReader();
+        try {
+            List<Item> items = reader.readItems("data/inventory_data.csv");
+            ConsoleUI.displayItems(items);
+        } catch (IOException e) {
+            System.err.println("Error reading inventory data: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Main` entry point in `com.smartexpiry` to read inventory data and display items

## Testing
- `javac -d out $(find src/main/java -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_684c30a39cd4832ea5284fd21cb6e3d4